### PR TITLE
Change setup-gcloud version

### DIFF
--- a/.github/workflows/composite/setup/action.yml
+++ b/.github/workflows/composite/setup/action.yml
@@ -21,7 +21,7 @@ runs:
         poetry install
       shell: bash
     - name: Setup Google Cloud
-      uses: "google-github-actions/setup-gcloud@master"
+      uses: "google-github-actions/setup-gcloud@v0"
       with:
         project_id: ${{ inputs.GCP_PROJECT_ID }}
     - id: auth


### PR DESCRIPTION
https://github.com/tosh2230/stairlight/runs/5707363512?check_suite_focus=true

```
Warning: google-github-actions/setup-gcloud is pinned at "master". We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.
Error: On [202](https://github.com/tosh2230/stairlight/runs/5707363512?check_suite_focus=true#step:4:202)2-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

While not recommended, you can still pin to the "master" branch by setting the environment variable "SETUP_GCLOUD_I_UNDERSTAND_USING_MASTER_WILL_BREAK_MY_WORKFLOW_ON_2022_04_05=1". However, on 2022-04-05 when the branch is renamed, all your workflows will begin failing with an obtuse and difficult to diagnose error message.

For more information, please see: https://github.com/google-github-actions/setup-gcloud/issues/539
```