### PR TITLE
Set default table name in mapping.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
 [![CI](https://github.com/tosh2230/stairlight/actions/workflows/ci.yml/badge.svg)](https://github.com/tosh2230/stairlight/actions/workflows/ci.yml)
 
-Stairlight is a table-level data lineage tool, detects table dependencies by SELECT queries.
+A table-level data lineage tool, detects table dependencies by SELECT queries.
 
 Queries can be read from following systems.
 

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -142,13 +142,13 @@ class Configurator:
         )
 
     def build_mapping_config(self, unmapped_templates: "list[dict]") -> OrderedDict:
-        """Create a OrderedDict for mapping.config
+        """Create a OrderedDict for mapping.yaml
 
         Args:
-            unmapped (list[dict]): unmapped settings that Stairlight detects
+            unmapped_templates (list[dict]): unmapped settings that Stairlight detects
 
         Returns:
-            OrderedDict: mapping.config template
+            OrderedDict: mapping.yaml template
         """
         mapping_config_dict = OrderedDict(
             {

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -186,7 +186,6 @@ class Configurator:
             ]
 
             # Parameters
-            parameters: OrderedDict = None
             if map_key.PARAMETERS in unmapped_template:
                 undefined_params: list[str] = unmapped_template.get(map_key.PARAMETERS)
                 parameters = OrderedDict()
@@ -194,7 +193,6 @@ class Configurator:
                     splitted_params = undefined_param.split(".")
                     create_nested_dict(keys=splitted_params, results=parameters)
 
-            if parameters:
                 mapping_values[config_key.TABLES][0][config_key.PARAMETERS] = parameters
                 if parameters in all_parameters:
                     global_parameters.update(parameters)

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -184,10 +184,6 @@ class Configurator:
                     }
                 )
             ]
-            if template.source_type == TemplateSourceType.REDASH:
-                mapping_values[config_key.TABLES][0][
-                    config_key.TABLE_NAME
-                ] = template.uri
 
             # Parameters
             parameters: OrderedDict = None

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -4,6 +4,7 @@ import re
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime, timezone
+from pathlib import Path
 
 import yaml
 
@@ -169,15 +170,7 @@ class Configurator:
                     config_key.TEMPLATE_SOURCE_TYPE: template.source_type.value,
                 }
             )
-
-            if template.source_type == TemplateSourceType.FILE:
-                values[config_key.FILE_SUFFIX] = template.key
-            elif template.source_type == TemplateSourceType.GCS:
-                values[config_key.URI] = template.uri
-                values[config_key.BUCKET_NAME] = template.bucket
-            elif template.source_type == TemplateSourceType.REDASH:
-                values[config_key.QUERY_ID] = template.query_id
-                values[config_key.DATA_SOURCE_NAME] = template.data_source_name
+            values.update(self.get_mapping_values(template=template))
 
             # Tables
             values[config_key.TABLES] = [OrderedDict({config_key.TABLE_NAME: None})]
@@ -225,6 +218,19 @@ class Configurator:
         ]
 
         return mapping_config_dict
+
+    @staticmethod
+    def get_mapping_values(template: Template) -> dict:
+        mapping_values: dict = {}
+        if template.source_type == TemplateSourceType.FILE:
+            mapping_values[config_key.FILE_SUFFIX] = template.key
+        elif template.source_type == TemplateSourceType.GCS:
+            mapping_values[config_key.URI] = template.uri
+            mapping_values[config_key.BUCKET_NAME] = template.bucket
+        elif template.source_type == TemplateSourceType.REDASH:
+            mapping_values[config_key.QUERY_ID] = template.query_id
+            mapping_values[config_key.DATA_SOURCE_NAME] = template.data_source_name
+        return mapping_values
 
 
 def create_nested_dict(

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -165,15 +165,17 @@ class Configurator:
         unmapped_template: dict
         for unmapped_template in unmapped_templates:
             template: Template = unmapped_template[map_key.TEMPLATE]
-            values = OrderedDict(
+            mapping_values = OrderedDict(
                 {
                     config_key.TEMPLATE_SOURCE_TYPE: template.source_type.value,
                 }
             )
-            values.update(self.get_mapping_values(template=template))
+            mapping_values.update(
+                self.get_mapping_values_by_template_type(template=template)
+            )
 
             # Tables
-            values[config_key.TABLES] = [
+            mapping_values[config_key.TABLES] = [
                 OrderedDict(
                     {
                         config_key.TABLE_NAME: self.get_default_table_name(
@@ -183,7 +185,9 @@ class Configurator:
                 )
             ]
             if template.source_type == TemplateSourceType.REDASH:
-                values[config_key.TABLES][0][config_key.TABLE_NAME] = template.uri
+                mapping_values[config_key.TABLES][0][
+                    config_key.TABLE_NAME
+                ] = template.uri
 
             # Parameters
             parameters: OrderedDict = None
@@ -195,19 +199,19 @@ class Configurator:
                     create_nested_dict(keys=splitted_params, results=parameters)
 
             if parameters:
-                values[config_key.TABLES][0][config_key.PARAMETERS] = parameters
+                mapping_values[config_key.TABLES][0][config_key.PARAMETERS] = parameters
                 if parameters in all_parameters:
                     global_parameters.update(parameters)
                 else:
                     all_parameters.append(parameters)
 
             # Labels
-            values[config_key.TABLES][0][config_key.LABELS] = OrderedDict(
+            mapping_values[config_key.TABLES][0][config_key.LABELS] = OrderedDict(
                 {"key": "value"}
             )
 
             mapping_config_dict[config_key.MAPPING_CONFIG_MAPPING_SECTION].append(
-                values
+                mapping_values
             )
 
         # Global section
@@ -228,7 +232,7 @@ class Configurator:
         return mapping_config_dict
 
     @staticmethod
-    def get_mapping_values(template: Template) -> dict:
+    def get_mapping_values_by_template_type(template: Template) -> dict:
         mapping_values: dict = {}
         if template.source_type == TemplateSourceType.FILE:
             mapping_values[config_key.FILE_SUFFIX] = template.key

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -173,7 +173,15 @@ class Configurator:
             values.update(self.get_mapping_values(template=template))
 
             # Tables
-            values[config_key.TABLES] = [OrderedDict({config_key.TABLE_NAME: None})]
+            values[config_key.TABLES] = [
+                OrderedDict(
+                    {
+                        config_key.TABLE_NAME: self.get_default_table_name(
+                            template=template
+                        )
+                    }
+                )
+            ]
             if template.source_type == TemplateSourceType.REDASH:
                 values[config_key.TABLES][0][config_key.TABLE_NAME] = template.uri
 
@@ -231,6 +239,15 @@ class Configurator:
             mapping_values[config_key.QUERY_ID] = template.query_id
             mapping_values[config_key.DATA_SOURCE_NAME] = template.data_source_name
         return mapping_values
+
+    @staticmethod
+    def get_default_table_name(template: Template) -> str:
+        default_table_name: str = None
+        if template.source_type == TemplateSourceType.REDASH:
+            default_table_name = template.uri
+        else:
+            default_table_name = Path(template.key).stem
+        return default_table_name
 
 
 def create_nested_dict(

--- a/src/stairlight/config.py
+++ b/src/stairlight/config.py
@@ -158,7 +158,8 @@ class Configurator:
             }
         )
 
-        all_parameters: list[OrderedDict] = []
+        # List(instead of Set) because OrderedDict is not hashable
+        parameters_set: list[OrderedDict] = []
         global_parameters: dict = {}
 
         # Mapping section
@@ -194,10 +195,10 @@ class Configurator:
                     create_nested_dict(keys=splitted_params, results=parameters)
 
                 mapping_values[config_key.TABLES][0][config_key.PARAMETERS] = parameters
-                if parameters in all_parameters:
+                if parameters in parameters_set:
                     global_parameters.update(parameters)
                 else:
-                    all_parameters.append(parameters)
+                    parameters_set.append(parameters)
 
             # Labels
             mapping_values[config_key.TABLES][0][config_key.LABELS] = OrderedDict(

--- a/tests/stairlight/test_config.py
+++ b/tests/stairlight/test_config.py
@@ -10,6 +10,16 @@ from src.stairlight.source.file import FileTemplate
 
 
 class TestSuccess:
+    @pytest.fixture(scope="class")
+    def file_template(self, configurator) -> FileTemplate:
+        return FileTemplate(
+            mapping_config=configurator.read(
+                prefix=config_key.MAPPING_CONFIG_FILE_PREFIX
+            ),
+            source_type=base.TemplateSourceType.FILE,
+            key="tests/sql/main/test_undefined.sql",
+        )
+
     def test_read_map(self, configurator):
         assert configurator.read(prefix=config_key.MAPPING_CONFIG_FILE_PREFIX)
 
@@ -36,17 +46,10 @@ class TestSuccess:
             config_key.STAIRLIGHT_CONFIG_SETTING_SECTION,
         ]
 
-    def test_build_mapping_template(self, configurator):
-        template = FileTemplate(
-            mapping_config=configurator.read(
-                prefix=config_key.MAPPING_CONFIG_FILE_PREFIX
-            ),
-            source_type=base.TemplateSourceType.FILE,
-            key="tests/sql/main/test_undefined.sql",
-        )
+    def test_build_mapping_template(self, configurator, file_template):
         unmapped_templates = [
             {
-                map_key.TEMPLATE: template,
+                map_key.TEMPLATE: file_template,
                 map_key.PARAMETERS: [
                     "params.main_table",
                     "params.sub_table_01",
@@ -58,12 +61,12 @@ class TestSuccess:
         global_value = OrderedDict({config_key.PARAMETERS: {}})
         mapping_value = OrderedDict(
             {
-                config_key.TEMPLATE_SOURCE_TYPE: template.source_type.value,
-                config_key.FILE_SUFFIX: template.key,
+                config_key.TEMPLATE_SOURCE_TYPE: file_template.source_type.value,
+                config_key.FILE_SUFFIX: file_template.key,
                 config_key.TABLES: [
                     OrderedDict(
                         {
-                            config_key.TABLE_NAME: None,
+                            config_key.TABLE_NAME: "test_undefined",
                             config_key.PARAMETERS: OrderedDict(
                                 {
                                     "params": {

--- a/tests/stairlight/test_config.py
+++ b/tests/stairlight/test_config.py
@@ -4,10 +4,7 @@ from collections import OrderedDict
 import pytest
 
 from src.stairlight import config_key, map_key
-from src.stairlight.config import (
-    ConfigKeyNotFoundException,
-    get_config_value,
-)
+from src.stairlight.config import ConfigKeyNotFoundException, get_config_value
 from src.stairlight.source.base import TemplateSourceType
 from src.stairlight.source.file import FileTemplate
 from src.stairlight.source.gcs import GcsTemplate

--- a/tests/stairlight/test_config.py
+++ b/tests/stairlight/test_config.py
@@ -164,6 +164,21 @@ class TestSuccess:
         }
         assert actual == expected
 
+    def test_get_default_table_name_file(self, configurator, file_template):
+        actual = configurator.get_default_table_name(template=file_template)
+        expected = "test_undefined"
+        assert actual == expected
+
+    def test_get_default_table_name_gcs(self, configurator, gcs_template):
+        actual = configurator.get_default_table_name(template=gcs_template)
+        expected = "one_line"
+        assert actual == expected
+
+    def test_get_default_table_name_redash(self, configurator, redash_template):
+        actual = configurator.get_default_table_name(template=redash_template)
+        expected = "Copy of (#4) New Query"
+        assert actual == expected
+
 
 class TestFailure:
     def test_get_config_value(self):


### PR DESCRIPTION
When executing check command, stairlight set a file name as a default table name in mapping.yaml.