### PR TITLE
Fix a init command bug

### DIFF
--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -116,7 +116,7 @@ class StairLight:
         Returns:
             bool: Exists stairlight configuration file or not
         """
-        return self._stairlight_config is not None
+        return len(self._stairlight_config.Include) > 0
 
     def _set_config(self) -> None:
         """Set configurations"""

--- a/tests/stairlight/test_cli.py
+++ b/tests/stairlight/test_cli.py
@@ -37,7 +37,7 @@ class TestSuccess:
         message = cli_main.command_init(
             stairlight=stairlight_init, args=self.parser.parse_args([])
         )
-        assert len(message) > 0
+        assert len(message) > 0 and "already exists" not in message
 
     @pytest.mark.integration
     def test_command_check(self, stairlight_save: StairLight):

--- a/tests/stairlight/test_stairlight.py
+++ b/tests/stairlight/test_stairlight.py
@@ -255,6 +255,15 @@ class TestStairLight:
         assert actual == expected
 
 
+@pytest.mark.integration
+class TestStairLightNoConfig:
+    stairlight = StairLight(config_dir="none")
+    stairlight.create_map()
+
+    def test_has_stairlight_config(self):
+        assert not self.stairlight.has_stairlight_config()
+
+
 class TestIsCyclic:
     def test_cyclic_each(self):
         node_list = ["1", "2", "1", "2", "1", "2", "1", "2"]


### PR DESCRIPTION
Fix a init command bug caused by StairLight.has_stairlight_config() always returns True.