### PR TITLE
Avoid outputting empty fields in map command

### DIFF
--- a/src/stairlight/map.py
+++ b/src/stairlight/map.py
@@ -160,7 +160,9 @@ class Map:
             dict[str, Any]: Combined global parameters
         """
         global_params: dict[str, Any] = self.get_global_params()
-        table_params: OrderedDict[str, Any] = table_attributes.Parameters
+        table_params: OrderedDict[str, Any] = (
+            table_attributes.Parameters or OrderedDict()
+        )
 
         # Table parameters are prioritized over global parameters
         return {**global_params, **table_params}
@@ -259,7 +261,7 @@ class Map:
             table_attributes=table_attributes
         )
         mapped_params: list[str] = create_dict_key_list(d=mapped_params_dict)
-        ignore_params: list[str] = table_attributes.IgnoreParameters
+        ignore_params: list[str] = table_attributes.IgnoreParameters or []
         unmapped_params: list[str] = list(
             set(template_params) - set(mapped_params) - set(ignore_params)
         )

--- a/src/stairlight/source/config.py
+++ b/src/stairlight/source/config.py
@@ -100,15 +100,15 @@ class StairlightConfig:
 
 @dataclass
 class MappingConfigGlobal:
-    Parameters: dict[str, Any] = field(default_factory=dict)
+    Parameters: dict[str, Any] | None = None
 
 
 @dataclass
 class MappingConfigMappingTable:
     TableName: str
-    IgnoreParameters: list[str] = field(default_factory=list)
-    Parameters: OrderedDict = field(default_factory=OrderedDict)
-    Labels: dict[str, Any] = field(default_factory=dict)
+    IgnoreParameters: list[str] | None = None
+    Parameters: OrderedDict | None = None
+    Labels: dict[str, Any] | None = None
 
 
 @dataclass
@@ -129,9 +129,9 @@ class MappingConfigMetadata:
 
 @dataclass
 class MappingConfig:
-    Global: OrderedDict = field(default_factory=OrderedDict)
+    Global: OrderedDict | None = None
     Mapping: list[OrderedDict] = field(default_factory=list)
-    Metadata: list[dict[str, Any]] = field(default_factory=list)
+    Metadata: list[dict[str, Any]] | None = None
 
     def get_global(self) -> MappingConfigGlobal:
         """Get a global section

--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -497,6 +497,8 @@ class StairLight:
         found_count: int = 0
         configured_label_key: str
         configured_label_value: str
+        if not configured_labels:
+            return False
         for configured_label_key, configured_label_value in configured_labels.items():
             for target_label in target_labels:
                 target_label_key = target_label.split(":")[0]

--- a/tests/stairlight/test_configurator.py
+++ b/tests/stairlight/test_configurator.py
@@ -81,7 +81,6 @@ class TestBuildMappingConfigFile:
             }
         ]
 
-        global_value: OrderedDict = OrderedDict({MappingConfigKey.PARAMETERS: {}})
         mapping_value = OrderedDict(
             {
                 MappingConfigKey.TEMPLATE_SOURCE_TYPE: file_template.source_type.value,
@@ -89,7 +88,6 @@ class TestBuildMappingConfigFile:
                     OrderedDict(
                         {
                             MappingConfigKey.TABLE_NAME: "test_undefined",
-                            MappingConfigKey.IGNORE_PARAMETERS: [],
                             MappingConfigKey.PARAMETERS: OrderedDict(
                                 {
                                     "params": {
@@ -99,7 +97,6 @@ class TestBuildMappingConfigFile:
                                     }
                                 }
                             ),
-                            MappingConfigKey.LABELS: OrderedDict(),
                         }
                     )
                 ],
@@ -107,18 +104,9 @@ class TestBuildMappingConfigFile:
             }
         )
 
-        metadata_value: OrderedDict = OrderedDict(
-            {
-                MappingConfigKey.TABLE_NAME: None,
-                MappingConfigKey.LABELS: OrderedDict(),
-            }
-        )
-
         expected = OrderedDict(
             {
-                MappingConfigKey.GLOBAL_SECTION: global_value,
                 MappingConfigKey.MAPPING_SECTION: [mapping_value],
-                MappingConfigKey.METADATA_SECTION: [metadata_value],
             }
         )
         actual = configurator.build_mapping_config(
@@ -152,7 +140,6 @@ class TestBuildMappingConfigGcs:
             }
         ]
 
-        global_value: OrderedDict = OrderedDict({MappingConfigKey.PARAMETERS: {}})
         mapping_value = OrderedDict(
             {
                 MappingConfigKey.TEMPLATE_SOURCE_TYPE: gcs_template.source_type.value,
@@ -160,7 +147,6 @@ class TestBuildMappingConfigGcs:
                     OrderedDict(
                         {
                             MappingConfigKey.TABLE_NAME: "cte_multi_line",
-                            MappingConfigKey.IGNORE_PARAMETERS: [],
                             MappingConfigKey.PARAMETERS: OrderedDict(
                                 {
                                     "params": {
@@ -170,7 +156,6 @@ class TestBuildMappingConfigGcs:
                                     }
                                 }
                             ),
-                            MappingConfigKey.LABELS: OrderedDict(),
                         }
                     )
                 ],
@@ -180,18 +165,9 @@ class TestBuildMappingConfigGcs:
             }
         )
 
-        metadata_value: OrderedDict = OrderedDict(
-            {
-                MappingConfigKey.TABLE_NAME: None,
-                MappingConfigKey.LABELS: {},
-            }
-        )
-
         expected = OrderedDict(
             {
-                MappingConfigKey.GLOBAL_SECTION: global_value,
                 MappingConfigKey.MAPPING_SECTION: [mapping_value],
-                MappingConfigKey.METADATA_SECTION: [metadata_value],
             }
         )
         actual = configurator.build_mapping_config(
@@ -224,7 +200,6 @@ class TestBuildMappingConfigRedash:
             }
         ]
 
-        global_value: OrderedDict = OrderedDict({MappingConfigKey.PARAMETERS: {}})
         mapping_value = OrderedDict(
             {
                 MappingConfigKey.TEMPLATE_SOURCE_TYPE: (
@@ -234,7 +209,6 @@ class TestBuildMappingConfigRedash:
                     OrderedDict(
                         {
                             MappingConfigKey.TABLE_NAME: "redash_test_query",
-                            MappingConfigKey.IGNORE_PARAMETERS: [],
                             MappingConfigKey.PARAMETERS: OrderedDict(
                                 {
                                     "params": {
@@ -244,7 +218,6 @@ class TestBuildMappingConfigRedash:
                                     }
                                 }
                             ),
-                            MappingConfigKey.LABELS: OrderedDict(),
                         }
                     )
                 ],
@@ -253,18 +226,9 @@ class TestBuildMappingConfigRedash:
             }
         )
 
-        metadata_value: OrderedDict = OrderedDict(
-            {
-                MappingConfigKey.TABLE_NAME: None,
-                MappingConfigKey.LABELS: {},
-            }
-        )
-
         expected = OrderedDict(
             {
-                MappingConfigKey.GLOBAL_SECTION: global_value,
                 MappingConfigKey.MAPPING_SECTION: [mapping_value],
-                MappingConfigKey.METADATA_SECTION: [metadata_value],
             }
         )
         actual = configurator.build_mapping_config(
@@ -301,7 +265,6 @@ class TestBuildMappingConfigDbt:
             }
         ]
 
-        global_value: OrderedDict = OrderedDict({MappingConfigKey.PARAMETERS: {}})
         mapping_value = OrderedDict(
             {
                 MappingConfigKey.TEMPLATE_SOURCE_TYPE: dbt_template.source_type.value,
@@ -309,7 +272,6 @@ class TestBuildMappingConfigDbt:
                     OrderedDict(
                         {
                             MappingConfigKey.TABLE_NAME: "my_first_dbt_model",
-                            MappingConfigKey.IGNORE_PARAMETERS: [],
                             MappingConfigKey.PARAMETERS: OrderedDict(
                                 {
                                     "params": {
@@ -319,7 +281,6 @@ class TestBuildMappingConfigDbt:
                                     }
                                 }
                             ),
-                            MappingConfigKey.LABELS: OrderedDict(),
                         }
                     )
                 ],
@@ -331,18 +292,9 @@ class TestBuildMappingConfigDbt:
             }
         )
 
-        metadata_value: OrderedDict = OrderedDict(
-            {
-                MappingConfigKey.TABLE_NAME: None,
-                MappingConfigKey.LABELS: {},
-            }
-        )
-
         expected = OrderedDict(
             {
-                MappingConfigKey.GLOBAL_SECTION: global_value,
                 MappingConfigKey.MAPPING_SECTION: [mapping_value],
-                MappingConfigKey.METADATA_SECTION: [metadata_value],
             }
         )
         actual = configurator.build_mapping_config(
@@ -376,7 +328,6 @@ class TestBuildMappingConfigS3:
             }
         ]
 
-        global_value: OrderedDict = OrderedDict({MappingConfigKey.PARAMETERS: {}})
         mapping_value = OrderedDict(
             {
                 MappingConfigKey.TEMPLATE_SOURCE_TYPE: s3_template.source_type.value,
@@ -384,7 +335,6 @@ class TestBuildMappingConfigS3:
                     OrderedDict(
                         {
                             MappingConfigKey.TABLE_NAME: "cte_multi_line",
-                            MappingConfigKey.IGNORE_PARAMETERS: [],
                             MappingConfigKey.PARAMETERS: OrderedDict(
                                 {
                                     "params": {
@@ -394,7 +344,6 @@ class TestBuildMappingConfigS3:
                                     }
                                 }
                             ),
-                            MappingConfigKey.LABELS: OrderedDict(),
                         }
                     )
                 ],
@@ -404,18 +353,9 @@ class TestBuildMappingConfigS3:
             }
         )
 
-        metadata_value: OrderedDict = OrderedDict(
-            {
-                MappingConfigKey.TABLE_NAME: None,
-                MappingConfigKey.LABELS: {},
-            }
-        )
-
         expected = OrderedDict(
             {
-                MappingConfigKey.GLOBAL_SECTION: global_value,
                 MappingConfigKey.MAPPING_SECTION: [mapping_value],
-                MappingConfigKey.METADATA_SECTION: [metadata_value],
             }
         )
         actual = configurator.build_mapping_config(


### PR DESCRIPTION
main branch

```yaml
Global:
  Parameters: {}
Mapping:
- TemplateSourceType: File
  Tables:
  - TableName: backtick_whole_element
    IgnoreParameters: []
    Parameters: {}
    Labels: {}
  FileSuffix: tests/sql/query/backtick_whole_element.sql
Metadata:
- TableName: null
  Labels: {}
```

this branch

```yaml
Mapping:
- TemplateSourceType: File
  Tables:
  - TableName: backtick_whole_element
  FileSuffix: tests/sql/query/backtick_whole_element.sql
```