### PR TITLE
Avoid to detect cases that string "from" is included at the end of column name

### DIFF
--- a/src/stairlight/query.py
+++ b/src/stairlight/query.py
@@ -74,7 +74,7 @@ class Query:
         query_group["cte"] = self.query_str[:boundary_num].strip()
 
         # Exclude table aliases from the main
-        table_pattern = r"(?:from|join)\s+([`.\-\w]+)"
+        table_pattern = r"\s(?:from|join)\s+([`.\-\w]+)"
         main_tables_with_alias: list[str] = re.findall(
             table_pattern, query_group["main"], re.IGNORECASE
         )

--- a/tests/sql/query/contains_str_from.sql
+++ b/tests/sql/query/contains_str_from.sql
@@ -1,0 +1,23 @@
+WITH cte AS (
+    SELECT
+        *
+    FROM
+        test.cte
+)
+
+SELECT
+    *
+FROM
+    test.main
+LEFT JOIN
+    test.sub ON
+        sub.id = main.id
+        AND main.date = sub.date
+LEFT JOIN
+    cte ON
+        cte.id = main.id
+        AND main.date
+        BETWEEN cte.date_from AND cte.date_to
+WHERE
+    sub.name = cte.name
+;

--- a/tests/stairlight/test_query.py
+++ b/tests/stairlight/test_query.py
@@ -237,6 +237,26 @@ class TestSuccess:
                     },
                 ],
             ),
+            (
+                "tests/sql/query/contains_str_from.sql",
+                [
+                    {
+                        MapKey.TABLE_NAME: "test.cte",
+                        MapKey.LINE_NUMBER: 5,
+                        MapKey.LINE_STRING: "        test.cte",
+                    },
+                    {
+                        MapKey.TABLE_NAME: "test.main",
+                        MapKey.LINE_NUMBER: 11,
+                        MapKey.LINE_STRING: "    test.main",
+                    },
+                    {
+                        MapKey.TABLE_NAME: "test.sub",
+                        MapKey.LINE_NUMBER: 13,
+                        MapKey.LINE_STRING: "    test.sub ON",
+                    },
+                ],
+            ),
         ],
         ids=[
             "tests/sql/query/cte_one_line.sql",
@@ -248,6 +268,7 @@ class TestSuccess:
             "tests/sql/query/backtick_each_elements.sql",
             "tests/sql/query/backtick_whole_element.sql",
             "tests/sql/query/google_bigquery_unnest_in_exists.sql",
+            "tests/sql/query/include_from_and_to_in_column_names.sql",
         ],
     )
     def test_detect_upstairs_attributes(self, file, expected):


### PR DESCRIPTION
String like "BETWEEN cte.date_**from AND** cte.date_to" will be parsed as "AND" table...