### PR TITLE
Rename "Metadata" to "ExtraLabels" in mapping.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Mapping:
     Uri: "s3://stairlight/sql/one_line/one_line.sql"
     Tables:
       - TableName: "PROJECT_as.DATASET_bs.TABLE_cs"
-Metadata:
+ExtraLabels:
   - TableName: "PROJECT_A.DATASET_A.TABLE_A"
     Labels:
       Source: Null
@@ -313,9 +313,9 @@ Mapping section is used to define relationships between input SELECT statements 
 
 In contrast, `IgnoreParameters` handles a list to ignore when rendering queries.
 
-#### Metadata Section
+#### Extra labels Section
 
-This section is used to set metadata to tables that appears only in queries.
+This section sets labels to tables that appears only in queries.
 
 ## Arguments and Options
 
@@ -366,12 +366,19 @@ optional arguments:
 `stairlight map` creates a new configuration file about undefined settings. `stairlight check` is an alias.
 Options are the same as `stairlight init`.
 
+### list
+
+`stairlight list` outputs all of tables or SQL URIs.
+
+- Output option(`-o`, `--output`) determines the output type, tables or URIs.
+
 ### up
 
 `stairlight up` outputs tables or SQL URIs located upstream(upstairs) from the specified table.
 
 - Use table(`-t`, `--table`) or label(`-l`, `--label`) option to specify tables to search.
-- Recursive option(`-r`, `--recursive`) is set, Stairlight will find tables recursively and output as a list.
+- Output option(`-o`, `--output`) is same as `stairlight list`.
+- Recursive option(`-r`, `--recursive`) is set, Stairlight will find dependencies recursively and output as a list.
 - Verbose option(`-v`, `--verbose`) is set, Stairlight will add detailed information and output it as a dict.
 
 ```txt
@@ -384,9 +391,9 @@ optional arguments:
   -c CONFIG, --config CONFIG
                         set a Stairlight configuration directory
   -q, --quiet           keep silence
-  --save SAVE           A file path where map results will be saved.
+  --save SAVE           A file path where mapped results will be saved.
                         You can choose from local file system, GCS, S3.
-  --load LOAD           A file path where map results are saved.
+  --load LOAD           A file path where mapped results are saved.
                         You can choose from local file system, GCS, S3.
                         It can be specified multiple times.
   -t TABLE, --table TABLE

--- a/src/stairlight/cli.py
+++ b/src/stairlight/cli.py
@@ -176,7 +176,7 @@ def set_save_load_parser(parser: argparse.ArgumentParser) -> None:
         "--save",
         help=textwrap.dedent(
             """\
-            A file path where map results will be saved.
+            A file path where mapped results will be saved.
             You can choose from local file system, GCS, S3.
         """
         ),
@@ -187,7 +187,7 @@ def set_save_load_parser(parser: argparse.ArgumentParser) -> None:
         "--load",
         help=textwrap.dedent(
             """\
-            A file path where map results are saved.
+            A file path where mapped results are saved.
             You can choose from local file system, GCS, S3.
             It can be specified multiple times.
         """
@@ -227,6 +227,20 @@ def set_search_parser(parser: argparse.ArgumentParser) -> None:
         ),
         action="append",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="return verbose results",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        help="search recursively",
+        action="store_true",
+        default=False,
+    )
 
 
 def set_output_parser(parser: argparse.ArgumentParser) -> None:
@@ -242,20 +256,6 @@ def set_output_parser(parser: argparse.ArgumentParser) -> None:
         type=str,
         choices=[ResponseType.TABLE.value, ResponseType.URI.value],
         default=ResponseType.TABLE.value,
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="return verbose results",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "-r",
-        "--recursive",
-        help="search recursively",
-        action="store_true",
-        default=False,
     )
 
 
@@ -305,8 +305,8 @@ def create_parser() -> argparse.ArgumentParser:
     parser_up.set_defaults(handler=command_up)
     set_general_parser(parser=parser_up)
     set_save_load_parser(parser=parser_up)
-    set_search_parser(parser=parser_up)
     set_output_parser(parser=parser_up)
+    set_search_parser(parser=parser_up)
 
     # down
     parser_down = subparsers.add_parser(
@@ -315,8 +315,8 @@ def create_parser() -> argparse.ArgumentParser:
     parser_down.set_defaults(handler=command_down)
     set_general_parser(parser=parser_down)
     set_save_load_parser(parser=parser_down)
-    set_search_parser(parser=parser_down)
     set_output_parser(parser=parser_down)
+    set_search_parser(parser=parser_down)
 
     return parser
 

--- a/src/stairlight/map.py
+++ b/src/stairlight/map.py
@@ -112,9 +112,9 @@ class Map:
         )
 
         downstairs: str = table_attributes.TableName
-        mapping_labels: dict[str, Any] = table_attributes.Labels
+        mapped_labels: dict[str, Any] = table_attributes.Labels
         if self._mapping_config:
-            metadata: list[dict[str, Any]] = self._mapping_config.Metadata
+            extra_labels: list[dict[str, Any]] = self._mapping_config.ExtraLabels
 
         if downstairs not in self.mapped:
             self.mapped[downstairs] = {}
@@ -125,8 +125,8 @@ class Map:
             if not self.mapped[downstairs].get(upstairs):
                 self.mapped[downstairs][upstairs] = self.create_upstairs_value(
                     template=template,
-                    mapping_labels=mapping_labels,
-                    metadata=metadata,
+                    mapped_labels=mapped_labels,
+                    extra_labels=extra_labels,
                     upstairs=upstairs,
                 )
 
@@ -172,22 +172,22 @@ class Map:
     @staticmethod
     def create_upstairs_value(
         template: Template,
-        mapping_labels: dict[str, Any],
-        metadata: list[dict[str, Any]],
+        mapped_labels: dict[str, Any],
+        extra_labels: list[dict[str, Any]],
         upstairs: str,
     ) -> dict[str, Any]:
         """create upstairs table information
 
         Args:
             template (Template): Template class
-            mapping_labels (dict[str, Any]): Labels in mapping section
-            metadata (list[dict[str, Any]]): Metadata
+            mapped_labels (dict[str, Any]): Labels in mapping section
+            extra_labels (list[dict[str, Any]]): Extra labels
             upstairs (str): Upstairs table's Name
 
         Returns:
             dict[str, Any]: upstairs table information
         """
-        metadata_labels: list[dict[str, Any]] = []
+        target_labels: list[dict[str, Any]] = []
         upstairs_values = {
             MapKey.TEMPLATE_SOURCE_TYPE: template.source_type.value,
             MapKey.KEY: template.key,
@@ -200,25 +200,25 @@ class Map:
         elif template.source_type == TemplateSourceType.REDASH:
             upstairs_values[MapKey.DATA_SOURCE_NAME] = template.data_source_name
 
-        if metadata:
-            metadata_labels = [
-                m.get(MappingConfigKey.LABELS, {})
-                for m in metadata
-                if m.get(MappingConfigKey.TABLE_NAME) == upstairs
+        if extra_labels:
+            target_labels = [
+                extra_label.get(MappingConfigKey.LABELS, {})
+                for extra_label in extra_labels
+                if extra_label.get(MappingConfigKey.TABLE_NAME) == upstairs
             ]
-        if mapping_labels or metadata_labels:
+        if mapped_labels or extra_labels:
             upstairs_values[MapKey.LABELS] = {}
 
-        if mapping_labels:
+        if mapped_labels:
             upstairs_values[MapKey.LABELS] = {
                 **upstairs_values[MapKey.LABELS],
-                **mapping_labels,
+                **mapped_labels,
             }
 
-        if metadata_labels:
+        if target_labels:
             upstairs_values[MapKey.LABELS] = {
                 **upstairs_values[MapKey.LABELS],
-                **metadata_labels[0],
+                **target_labels[0],
             }
         return upstairs_values
 

--- a/src/stairlight/source/config.py
+++ b/src/stairlight/source/config.py
@@ -124,7 +124,7 @@ class MappingConfigMapping:
 
 
 @dataclass
-class MappingConfigMetadata:
+class MappingConfigExtraLabels:
     TableName: str | None = None
     Labels: dict[str, Any] = field(default_factory=dict)
 
@@ -133,7 +133,8 @@ class MappingConfigMetadata:
 class MappingConfig:
     Global: OrderedDict | None = None
     Mapping: list[OrderedDict] = field(default_factory=list)
-    Metadata: list[dict[str, Any]] | None = None
+    ExtraLabels: list[dict[str, Any]] | None = None
+    Metadata: list[dict[str, Any]] | None = None  # Deprecated
 
     def get_global(self) -> MappingConfigGlobal:
         """Get a global section
@@ -159,14 +160,22 @@ class MappingConfig:
             )
             yield mapping_config(**_mapping)
 
-    def get_metadata(self) -> Iterator[MappingConfigMetadata]:
-        """Get a metadata section
+    def get_extra_labels(self) -> Iterator[MappingConfigExtraLabels]:
+        """Get a labelers section
 
         Yields:
-            Iterator[MappingConfigMetadata]: Metadata section
+            Iterator[MappingConfigExtraLabels]: Extra labels section
         """
-        for _metadata in self.Metadata:
-            yield MappingConfigMetadata(**_metadata)
+        if not self.ExtraLabels:
+            return
+        for extra_label in self.ExtraLabels:
+            yield MappingConfigExtraLabels(**extra_label)
+
+        # Deprecated
+        if not self.Metadata:
+            return
+        for metadata in self.Metadata:
+            yield MappingConfigExtraLabels(**metadata)
 
     @staticmethod
     def select_mapping_config(source_type: str) -> Type[MappingConfigMapping]:

--- a/src/stairlight/source/config.py
+++ b/src/stairlight/source/config.py
@@ -137,7 +137,7 @@ class MappingConfig:
     Metadata: list[dict[str, Any]] | None = None  # Deprecated
 
     def get_global(self) -> MappingConfigGlobal:
-        """Get a global section
+        """Get global section
 
         Returns:
             MappingConfigGlobal: Global section
@@ -149,7 +149,7 @@ class MappingConfig:
         return mapping_config_global
 
     def get_mapping(self) -> Iterator[MappingConfigMapping]:
-        """Get a mapping section
+        """Get mapping section
 
         Yields:
             Iterator[MappingConfigMapping]: Mapping section
@@ -161,7 +161,7 @@ class MappingConfig:
             yield mapping_config(**_mapping)
 
     def get_extra_labels(self) -> Iterator[MappingConfigExtraLabels]:
-        """Get a labelers section
+        """Get extra labels section
 
         Yields:
             Iterator[MappingConfigExtraLabels]: Extra labels section

--- a/src/stairlight/source/config_key.py
+++ b/src/stairlight/source/config_key.py
@@ -56,7 +56,9 @@ class StairlightConfigKey(Key):
 class MappingConfigKey(Key):
     GLOBAL_SECTION = "Global"
     MAPPING_SECTION = "Mapping"
-    METADATA_SECTION = "Metadata"
+
+    METADATA_SECTION = "Metadata"  # Deprecated
+    EXTRA_LABELS_SECTION = "ExtraLabels"
 
     TEMPLATE_SOURCE_TYPE = "TemplateSourceType"
     TABLES = "Tables"

--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -495,7 +495,7 @@ class StairLight:
         """
         tables_to_search: list[str] = []
 
-        # "mapping" section in mapping.yaml
+        # "Mapping" section in mapping.yaml
         if not self._mapping_config:
             return tables_to_search
 
@@ -510,16 +510,16 @@ class StairLight:
                 ):
                     tables_to_search.append(mapping_table.TableName)
 
-        # "metadata" section in mapping.yaml
-        for metadata in self._mapping_config.get_metadata():
+        # "ExtraLabels" section in mapping.yaml
+        for extra_label in self._mapping_config.get_extra_labels():
             if (
-                metadata.TableName not in tables_to_search
+                extra_label.TableName not in tables_to_search
                 and self.is_target_label_found(
                     target_labels=target_labels,
-                    configured_labels=metadata.Labels,
+                    configured_labels=extra_label.Labels,
                 )
             ):
-                tables_to_search.append(str(metadata.TableName))
+                tables_to_search.append(str(extra_label.TableName))
 
         return tables_to_search
 

--- a/tests/config/mapping.yaml
+++ b/tests/config/mapping.yaml
@@ -142,3 +142,8 @@ Metadata:
     Labels:
       Source: Null
       Test: a
+ExtraLabels:
+  - TableName: "PROJECT_A.DATASET_A.TABLE_A"
+    Labels:
+      Source: Null
+      Test: a

--- a/tests/config/mapping_file.yaml
+++ b/tests/config/mapping_file.yaml
@@ -119,7 +119,7 @@ Mapping:
         Labels:
           Source: s3
           Test: c
-Metadata:
+ExtraLabels:
   - TableName: "PROJECT_A.DATASET_A.TABLE_A"
     Labels:
       Source: Null

--- a/tests/stairlight/source/test_config.py
+++ b/tests/stairlight/source/test_config.py
@@ -10,8 +10,8 @@ class TestMappingConfigEmpty:
 
     def test_get_mapping(self):
         mapping_config = MappingConfig(Mapping=[OrderedDict({})])
-        assert mapping_config.get_global()
+        assert mapping_config.get_mapping()
 
-    def test_get_metadata(self):
+    def test_get_extra_labels(self):
         mapping_config = MappingConfig(Mapping=[OrderedDict({})])
-        assert mapping_config.get_global()
+        assert mapping_config.get_extra_labels()

--- a/tests/stairlight/test_map.py
+++ b/tests/stairlight/test_map.py
@@ -168,7 +168,7 @@ class TestSuccess:
 
 
 @pytest.mark.integration
-class TestSuccessNoMetadata:
+class TestSuccessNoExtraLables:
     def test_find_unmapped_params(self, dependency_map: Map):
         assert dependency_map.unmapped
 


### PR DESCRIPTION
Role of "Metadata" section is to label tables that appear only in queries, so that I rename it "ExtraLabels" to match its role.
"Metadata" is still available, but deprecated.