### PR TITLE
Detects tables having same upstairs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1095,14 +1095,14 @@ protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4
 
 [[package]]
 name = "google-cloud-storage"
-version = "2.7.0"
+version = "2.8.0"
 description = "Google Cloud Storage API client library"
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-storage-2.7.0.tar.gz", hash = "sha256:1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17"},
-    {file = "google_cloud_storage-2.7.0-py2.py3-none-any.whl", hash = "sha256:f78a63525e72dd46406b255bbdf858a22c43d6bad8dc5bdeb7851a42967e95a1"},
+    {file = "google-cloud-storage-2.8.0.tar.gz", hash = "sha256:4388da1ff5bda6d729f26dbcaf1bfa020a2a52a7b91f0a8123edbda51660802c"},
+    {file = "google_cloud_storage-2.8.0-py2.py3-none-any.whl", hash = "sha256:248e210c13bc109909160248af546a91cb2dabaf3d7ebbf04def9dd49f02dbb6"},
 ]
 
 [package.dependencies]
@@ -2656,7 +2656,7 @@ name = "sqlparse"
 version = "0.4.4"
 description = "A non-validating SQL parser."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sqlparse-0.4.4-py3-none-any.whl", hash = "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3"},

--- a/src/stairlight/cli.py
+++ b/src/stairlight/cli.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import textwrap
+from dataclasses import asdict
 from typing import Any, Callable
 
 from src import stairlight
+from src.stairlight.map import Stair
 
 
 def command_init(stairlight: stairlight.StairLight, args: argparse.Namespace) -> str:
@@ -341,25 +343,34 @@ def main() -> None:
     )
     _stairlight.create_map()
 
-    result = None
+    result_command: Any = None
+    result_mapped: dict[str, list[Stair | None]] = {}
     if hasattr(args, "handler"):
         if args.handler == command_init and _stairlight.has_stairlight_config():
             exit(f"'{args.config}/stairlight.y(a)ml' already exists.")
         elif args.handler != command_init and not _stairlight.has_stairlight_config():
             exit(f"'{args.config}/stairlight.y(a)ml' is not found.")
-        result = args.handler(_stairlight, args)
+        result_command = args.handler(_stairlight, args)
     else:
         if not _stairlight.has_stairlight_config():
             exit(f"'{args.config}/stairlight.y(a)ml' is not found.")
-        result = _stairlight.mapped
+        result_mapped = _stairlight.mapped
 
-    if args.quiet or not result:
+    if args.quiet or (not result_command and not result_mapped):
         return
 
-    if result and isinstance(result, str):
-        print(result)
-    else:
-        print(json.dumps(result, indent=2))
+    if result_command and isinstance(result_command, str):
+        print(result_command)
+    elif result_command:
+        print(json.dumps(result_command, indent=2))
+    elif result_mapped:
+        result_dict: dict = {}
+        for table_name, stairs in result_mapped.items():
+            result_dict = {
+                **result_dict,
+                **{table_name: asdict(stair) for stair in stairs},
+            }
+        print(json.dumps(result_dict, indent=2))
 
 
 if __name__ == "__main__":

--- a/src/stairlight/cli.py
+++ b/src/stairlight/cli.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import argparse
 import json
 import textwrap
-from dataclasses import asdict
 from typing import Any, Callable
 
 from src import stairlight
-from src.stairlight.map import Stair
+from src.stairlight.map import MappedTemplate
 
 
 def command_init(stairlight: stairlight.StairLight, args: argparse.Namespace) -> str:
@@ -344,7 +343,7 @@ def main() -> None:
     _stairlight.create_map()
 
     result_command: Any = None
-    result_mapped: dict[str, list[Stair | None]] = {}
+    result_mapped: dict[str, dict[str, list[MappedTemplate] | None] | None] = {}
     if hasattr(args, "handler"):
         if args.handler == command_init and _stairlight.has_stairlight_config():
             exit(f"'{args.config}/stairlight.y(a)ml' already exists.")
@@ -364,12 +363,9 @@ def main() -> None:
     elif result_command:
         print(json.dumps(result_command, indent=2))
     elif result_mapped:
-        result_dict: dict = {}
-        for table_name, stairs in result_mapped.items():
-            result_dict = {
-                **result_dict,
-                **{table_name: asdict(stair) for stair in stairs},
-            }
+        result_dict: dict[str, Any] = _stairlight.cast_mapped_dict_all(
+            mapped=result_mapped
+        )
         print(json.dumps(result_dict, indent=2))
 
 

--- a/src/stairlight/map.py
+++ b/src/stairlight/map.py
@@ -59,7 +59,7 @@ class Map:
             mapping_config (MappingConfig):
                 Mapping configurations.
             mapped (dict[str, Any], optional):
-                Mapped table attributes. Defaults to None.
+                Mapped templates. Defaults to None.
         """
         if mapped:
             self.mapped = mapped

--- a/src/stairlight/query.py
+++ b/src/stairlight/query.py
@@ -6,13 +6,13 @@ from typing import Iterator
 
 
 @dataclass
-class UpstairsTableReference:
+class UpstairTableReference:
     TableName: str
     Line: dict
 
 
 @dataclass
-class UpstairsTableReferenceLine:
+class UpstairTableReferenceLine:
     LineNumber: int
     LineString: str
 
@@ -32,7 +32,7 @@ class Query:
         self.query_str = query_str
         self.default_table_prefix = default_table_prefix
 
-    def detect_upstairs_table_reference(self) -> Iterator[UpstairsTableReference]:
+    def detect_upstair_table_reference(self) -> Iterator[UpstairTableReference]:
         """Parse a query statement and detect a upstream table reference
 
         Yields:
@@ -57,10 +57,10 @@ class Query:
                     if self.default_table_prefix
                     else upstairs_table
                 )
-                yield UpstairsTableReference(
+                yield UpstairTableReference(
                     TableName=table_name.replace("`", ""),
                     Line=asdict(
-                        UpstairsTableReferenceLine(
+                        UpstairTableReferenceLine(
                             LineNumber=line_index + 1,
                             LineString=self.query_str.splitlines()[line_index],
                         )

--- a/src/stairlight/query.py
+++ b/src/stairlight/query.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Iterator
 
-from src.stairlight.source.config import MapKey
+
+@dataclass
+class UpstairsReference:
+    TableName: str
+    LineNumber: int
+    LineString: str
 
 
 class Query:
@@ -21,11 +27,11 @@ class Query:
         self.query_str = query_str
         self.default_table_prefix = default_table_prefix
 
-    def detect_upstairs_attributes(self) -> Iterator[dict]:
-        """Parse a query statement and detect upstream table attributes
+    def detect_upstairs_reference(self) -> Iterator[UpstairsReference]:
+        """Parse a query statement and detect a upstream table reference
 
         Yields:
-            Iterator[dict]: upstream table attributes
+            Iterator[UpstairsResults]: upstream table results
         """
         upstairs_tables = self.parse_and_get_upstairs_tables()
 
@@ -45,11 +51,11 @@ class Query:
                     )
                 else:
                     table_name = upstairs_table
-                yield {
-                    MapKey.TABLE_NAME: table_name.replace("`", ""),  # for BigQuery
-                    MapKey.LINE_NUMBER: line_index + 1,
-                    MapKey.LINE_STRING: self.query_str.splitlines()[line_index],
-                }
+                yield UpstairsReference(
+                    TableName=table_name.replace("`", ""),
+                    LineNumber=line_index + 1,
+                    LineString=self.query_str.splitlines()[line_index],
+                )
 
     def parse_and_get_upstairs_tables(self) -> list[str]:
         """Parse query and get upstairs tables

--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -379,7 +379,7 @@ class StairLight:
             target_table_name=table_name, direction=direction
         )
 
-        for next_table_name, attributes_list in relative_map.items():
+        for next_table_name, templates in relative_map.items():
             if recursive:
                 if head:
                     searched_tables = [table_name]
@@ -395,7 +395,9 @@ class StairLight:
                     logger.warning(f"Circular references detected!: {details}")
                     continue
 
-            for attributes in attributes_list:
+            search_results[next_table_name] = {}
+            search_results[next_table_name]["Templates"] = []
+            for template in templates:
                 if recursive:
                     next_response = self.search_verbose(
                         table_name=next_table_name,
@@ -408,8 +410,7 @@ class StairLight:
                     if not next_response.get(next_table_name):
                         continue
 
-                    search_results[next_table_name] = {}
-                    search_results[next_table_name]["Attributes"] = relative_map[
+                    search_results[next_table_name]["Templates"] = relative_map[
                         next_table_name
                     ]
                     if next_response[next_table_name][direction.value]:
@@ -417,9 +418,7 @@ class StairLight:
                             direction.value
                         ] = next_response[next_table_name][direction.value]
                 else:
-                    for attributes in attributes_list:
-                        search_results[table_name] = {}
-                        search_results[table_name]["Attributes"] = attributes
+                    search_results[table_name]["Templates"].append(template)
 
         response[table_name][direction.value] = search_results
         return response
@@ -454,7 +453,7 @@ class StairLight:
             return response
 
         next_table_name: str
-        for next_table_name, attributes_list in relative_map.items():
+        for next_table_name, templates in relative_map.items():
             if recursive:
                 if head:
                     searched_tables = []
@@ -471,7 +470,7 @@ class StairLight:
                     logger.info(f"Circular reference detected!: {details}")
                     continue
 
-            for attributes in attributes_list:
+            for template in templates:
                 if recursive:
                     next_response = self.search_plain(
                         table_name=next_table_name,
@@ -486,7 +485,7 @@ class StairLight:
                 if response_type == ResponseType.TABLE.value:
                     response.append(next_table_name)
                 elif response_type == ResponseType.URI.value:
-                    uri = attributes.get(MapKey.URI)
+                    uri = template.get(MapKey.URI)
                     if uri:
                         response.append(uri)
 

--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -119,20 +119,6 @@ class StairLight:
         )
         save_map_controller.save()
 
-    @staticmethod
-    def cast_mapped_dict_all(mapped: dict) -> dict[str, Any]:
-        casted: dict[str, Any] = {}
-        for table_name, upstair in mapped.items():
-            if not casted.get(table_name):
-                casted[table_name] = {}
-            for upstair_name, mapped_templates in upstair.items():
-                if not casted[table_name].get(upstair_name):
-                    casted[table_name][upstair_name] = []
-                for mapped_template in mapped_templates:
-                    if mapped_template and isinstance(mapped_template, MappedTemplate):
-                        casted[table_name][upstair_name].append(asdict(mapped_template))
-        return casted
-
     def load_map(self) -> None:
         """Load mapped results"""
         if not self.load_files:
@@ -603,3 +589,19 @@ class StairLight:
                     found_count += 1
 
         return found_count == len(target_labels)
+
+    @staticmethod
+    def cast_mapped_dict_all(
+        mapped: dict[str, dict[str, list[MappedTemplate] | None]]
+    ) -> dict[str, Any]:
+        casted: dict[str, Any] = {}
+        for table_name, upstair in mapped.items():
+            if not casted.get(table_name):
+                casted[table_name] = {}
+            for upstair_name, mapped_templates in upstair.items():
+                if not casted[table_name].get(upstair_name):
+                    casted[table_name][upstair_name] = []
+                for mapped_template in mapped_templates:
+                    if mapped_template and isinstance(mapped_template, MappedTemplate):
+                        casted[table_name][upstair_name].append(asdict(mapped_template))
+        return casted

--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -593,12 +593,12 @@ class StairLight:
     @staticmethod
     def cast_mapped_dict_all(
         mapped: dict[str, dict[str, list[MappedTemplate] | None]]
-    ) -> dict[str, Any]:
+    ) -> dict[str, dict[str, list[dict] | None]]:
         casted: dict[str, Any] = {}
-        for table_name, upstair in mapped.items():
+        for table_name, upstairs in mapped.items():
             if not casted.get(table_name):
                 casted[table_name] = {}
-            for upstair_name, mapped_templates in upstair.items():
+            for upstair_name, mapped_templates in upstairs.items():
                 if not casted[table_name].get(upstair_name):
                     casted[table_name][upstair_name] = []
                 for mapped_template in mapped_templates:

--- a/src/stairlight/stairlight.py
+++ b/src/stairlight/stairlight.py
@@ -467,7 +467,7 @@ class StairLight:
                         "next_table_name": next_table_name,
                         "searched_tables": searched_tables,
                     }
-                    logger.info(f"Circular reference detected!: {details}")
+                    logger.info(f"Circular references detected!: {details}")
                     continue
 
             for template in templates:

--- a/tests/config/mapping.yaml
+++ b/tests/config/mapping.yaml
@@ -51,6 +51,18 @@ Mapping:
           Source: file
           Test: c
   - TemplateSourceType: File
+    FileSuffix: "tests/sql/main/cte_multi_line_params_copy.sql"
+    Tables:
+      - TableName: "PROJECT_J.DATASET_K.TABLE_L"
+        Parameters:
+          params:
+            main_table: "PROJECT_P.DATASET_Q.TABLE_R"
+            sub_table_01: "PROJECT_S.DATASET_T.TABLE_U"
+            sub_table_02: "PROJECT_V.DATASET_W.TABLE_X"
+        Labels:
+          Source: file
+          Test: c
+  - TemplateSourceType: File
     FileSuffix: "tests/sql/main/one_line_1.sql"
     Tables:
       - TableName: "PROJECT_j.DATASET_k.TABLE_l"

--- a/tests/config/mapping_file.yaml
+++ b/tests/config/mapping_file.yaml
@@ -51,6 +51,18 @@ Mapping:
           Source: file
           Test: c
   - TemplateSourceType: File
+    FileSuffix: "tests/sql/main/cte_multi_line_params_copy.sql"
+    Tables:
+      - TableName: "PROJECT_J.DATASET_K.TABLE_L"
+        Parameters:
+          params:
+            main_table: "PROJECT_P.DATASET_Q.TABLE_R"
+            sub_table_01: "PROJECT_S.DATASET_T.TABLE_U"
+            sub_table_02: "PROJECT_V.DATASET_W.TABLE_X"
+        Labels:
+          Source: file
+          Test: c
+  - TemplateSourceType: File
     FileSuffix: "tests/sql/main/one_line_1.sql"
     Tables:
       - TableName: "PROJECT_j.DATASET_k.TABLE_l"

--- a/tests/sql/main/cte_multi_line_params_copy.sql
+++ b/tests/sql/main/cte_multi_line_params_copy.sql
@@ -1,0 +1,38 @@
+WITH c AS (
+    SELECT
+        test_id,
+        col_c
+    FROM
+        {{ params.sub_table_01 }}
+    WHERE
+        0 = 0
+),
+d AS (
+    SELECT
+        test_id,
+        col_d
+    FROM
+        {{ params.sub_table_02 }}
+    WHERE
+        0 = 0
+),
+e AS (
+    SELECT
+        test_id,
+        col_d
+    FROM
+        {{ params.sub_table_02 }}
+    WHERE
+        0 = 0
+)
+
+SELECT
+    *
+FROM
+    {{ params.main_table }} AS b
+    INNER JOIN c
+        ON b.test_id = c.test_id
+    INNER JOIN d
+        ON b.test_id = d.test_id
+WHERE
+    1 = 1

--- a/tests/stairlight/source/file/test_template.py
+++ b/tests/stairlight/source/file/test_template.py
@@ -24,11 +24,13 @@ from src.stairlight.source.template import RenderingTemplateException
     ("key", "expected_is_mapped"),
     [
         ("tests/sql/main/cte_multi_line_params.sql", True),
+        ("tests/sql/main/cte_multi_line_params_copy.sql", True),
         ("tests/sql/main/undefined.sql", False),
         ("tests/sql/gcs/cte/cte_multi_line.sql", False),
     ],
     ids=[
         "tests/sql/main/cte_multi_line_params.sql",
+        "tests/sql/main/cte_multi_line_params_copy.sql",
         "tests/sql/main/undefined.sql",
         "tests/sql/gcs/cte/cte_multi_line.sql",
     ],

--- a/tests/stairlight/test_cli.py
+++ b/tests/stairlight/test_cli.py
@@ -132,7 +132,7 @@ class TestSuccess:
         monkeypatch.setattr("sys.argv", ["", "-c", "tests/config"])
         cli_main.main()
         out, err = capfd.readouterr()
-        assert len(out) > 0 and len(err) == 0
+        assert "PROJECT_d.DATASET_e.TABLE_f" in out and len(err) == 0
 
     @pytest.mark.integration
     def test_main_quiet(self, monkeypatch, capfd):

--- a/tests/stairlight/test_map.py
+++ b/tests/stairlight/test_map.py
@@ -45,23 +45,24 @@ class TestSuccess:
     @pytest.mark.parametrize(
         "template_source_type",
         [
-            TemplateSourceType.FILE.value,
-            TemplateSourceType.GCS.value,
-            # TemplateSourceType.REDASH.value,
-            TemplateSourceType.DBT.value,
-            TemplateSourceType.S3.value,
+            TemplateSourceType.FILE,
+            TemplateSourceType.GCS,
+            # TemplateSourceType.REDASH,
+            TemplateSourceType.DBT,
+            TemplateSourceType.S3,
         ],
     )
-    def test_mapped_items(self, dependency_map: Map, template_source_type: str):
+    def test_mapped_items(
+        self, dependency_map: Map, template_source_type: TemplateSourceType
+    ):
         found: bool = False
-        upstairs_items: dict
-        upstairs_attributes: dict
-        for _, upstairs_items in dependency_map.mapped.items():
-            for _, upstairs_attributes in upstairs_items.items():
-                if (
-                    upstairs_attributes.get(MapKey.TEMPLATE_SOURCE_TYPE)
-                    == template_source_type
-                ):
+        for stairs in dependency_map.mapped.values():
+            for stair in stairs:
+                for _ in [
+                    table
+                    for table in stair.tables
+                    if table.TemplateSourceType == template_source_type.value
+                ]:
                     found = True
                     break
 

--- a/tests/stairlight/test_map.py
+++ b/tests/stairlight/test_map.py
@@ -56,13 +56,16 @@ class TestSuccess:
         self, dependency_map: Map, template_source_type: TemplateSourceType
     ):
         found: bool = False
-        for stairs in dependency_map.mapped.values():
-            for stair in stairs:
-                for _ in [
-                    table
-                    for table in stair.tables
-                    if table.TemplateSourceType == template_source_type.value
-                ]:
+        for upstairs in dependency_map.mapped.values():
+            for mapped_templates in upstairs.values():
+                if any(
+                    [
+                        mapped_template
+                        for mapped_template in mapped_templates
+                        if mapped_template.TemplateSourceType
+                        == template_source_type.value
+                    ]
+                ):
                     found = True
                     break
 

--- a/tests/stairlight/test_query.py
+++ b/tests/stairlight/test_query.py
@@ -1,6 +1,7 @@
 import pytest
 
-from src.stairlight.query import Query, UpstairsReference, solve_table_prefix
+from src.stairlight.query import Query, UpstairsTableReference, solve_table_prefix
+from src.stairlight.source.config import MapKey
 
 
 class TestSuccess:
@@ -10,19 +11,25 @@ class TestSuccess:
             "INNER JOIN PROJECT_X.DATASET_X.TABLE_Y USING(ID)"
         )
         query = Query(query_str=query_str)
-        results: list[UpstairsReference] = []
-        for result in query.detect_upstairs_reference():
+        results: list[UpstairsTableReference] = []
+        for result in query.detect_upstairs_table_reference():
             results.append(result)
         assert results == [
-            UpstairsReference(
+            UpstairsTableReference(
                 TableName="PROJECT_X.DATASET_X.TABLE_X",
-                LineNumber=1,
-                LineString="SELECT * FROM PROJECT_X.DATASET_X.TABLE_X ",
+                Line={
+                    MapKey.LINE_NUMBER: 1,
+                    MapKey.LINE_STRING: "SELECT * FROM PROJECT_X.DATASET_X.TABLE_X ",
+                },
             ),
-            UpstairsReference(
+            UpstairsTableReference(
                 TableName="PROJECT_X.DATASET_X.TABLE_Y",
-                LineNumber=2,
-                LineString=("INNER JOIN PROJECT_X.DATASET_X.TABLE_Y USING(ID)"),
+                Line={
+                    MapKey.LINE_NUMBER: 2,
+                    MapKey.LINE_STRING: (
+                        "INNER JOIN PROJECT_X.DATASET_X.TABLE_Y USING(ID)"
+                    ),
+                },
             ),
         ]
 
@@ -32,211 +39,272 @@ class TestSuccess:
             (
                 "tests/sql/query/cte_one_line.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_B.DATASET_B.TABLE_B",
-                        LineNumber=1,
-                        LineString=(
-                            "WITH c AS (SELECT test_id, col_c "
-                            "FROM PROJECT_C.DATASET_C.TABLE_C WHERE 0 = 0),"
-                            "d AS ("
-                            "SELECT test_id, col_d "
-                            "FROM PROJECT_d.DATASET_d.TABLE_d "
-                            "WHERE 0 = 0) "
-                            "SELECT * FROM PROJECT_B.DATASET_B.TABLE_B AS b "
-                            "INNER JOIN c ON b.test_id = c.test_id "
-                            "INNER JOIN d ON b.test_id = d.test_id WHERE 1 = 1"
-                        ),
+                        Line={
+                            MapKey.LINE_NUMBER: 1,
+                            MapKey.LINE_STRING: (
+                                "WITH c AS (SELECT test_id, col_c "
+                                "FROM PROJECT_C.DATASET_C.TABLE_C WHERE 0 = 0),"
+                                "d AS ("
+                                "SELECT test_id, col_d "
+                                "FROM PROJECT_d.DATASET_d.TABLE_d "
+                                "WHERE 0 = 0) "
+                                "SELECT * FROM PROJECT_B.DATASET_B.TABLE_B AS b "
+                                "INNER JOIN c ON b.test_id = c.test_id "
+                                "INNER JOIN d ON b.test_id = d.test_id WHERE 1 = 1"
+                            ),
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
-                        LineNumber=1,
-                        LineString=(
-                            "WITH c AS (SELECT test_id, col_c "
-                            "FROM PROJECT_C.DATASET_C.TABLE_C WHERE 0 = 0),"
-                            "d AS ("
-                            "SELECT test_id, col_d "
-                            "FROM PROJECT_d.DATASET_d.TABLE_d "
-                            "WHERE 0 = 0) "
-                            "SELECT * FROM PROJECT_B.DATASET_B.TABLE_B AS b "
-                            "INNER JOIN c ON b.test_id = c.test_id "
-                            "INNER JOIN d ON b.test_id = d.test_id WHERE 1 = 1"
-                        ),
+                        Line={
+                            MapKey.LINE_NUMBER: 1,
+                            MapKey.LINE_STRING: (
+                                "WITH c AS (SELECT test_id, col_c "
+                                "FROM PROJECT_C.DATASET_C.TABLE_C WHERE 0 = 0),"
+                                "d AS ("
+                                "SELECT test_id, col_d "
+                                "FROM PROJECT_d.DATASET_d.TABLE_d "
+                                "WHERE 0 = 0) "
+                                "SELECT * FROM PROJECT_B.DATASET_B.TABLE_B AS b "
+                                "INNER JOIN c ON b.test_id = c.test_id "
+                                "INNER JOIN d ON b.test_id = d.test_id WHERE 1 = 1"
+                            ),
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_d.DATASET_d.TABLE_d",
-                        LineNumber=1,
-                        LineString=(
-                            "WITH c AS (SELECT test_id, col_c "
-                            "FROM PROJECT_C.DATASET_C.TABLE_C WHERE 0 = 0),"
-                            "d AS ("
-                            "SELECT test_id, col_d "
-                            "FROM PROJECT_d.DATASET_d.TABLE_d "
-                            "WHERE 0 = 0) "
-                            "SELECT * FROM PROJECT_B.DATASET_B.TABLE_B AS b "
-                            "INNER JOIN c ON b.test_id = c.test_id "
-                            "INNER JOIN d ON b.test_id = d.test_id WHERE 1 = 1"
-                        ),
+                        Line={
+                            MapKey.LINE_NUMBER: 1,
+                            MapKey.LINE_STRING: (
+                                "WITH c AS (SELECT test_id, col_c "
+                                "FROM PROJECT_C.DATASET_C.TABLE_C WHERE 0 = 0),"
+                                "d AS ("
+                                "SELECT test_id, col_d "
+                                "FROM PROJECT_d.DATASET_d.TABLE_d "
+                                "WHERE 0 = 0) "
+                                "SELECT * FROM PROJECT_B.DATASET_B.TABLE_B AS b "
+                                "INNER JOIN c ON b.test_id = c.test_id "
+                                "INNER JOIN d ON b.test_id = d.test_id WHERE 1 = 1"
+                            ),
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/cte_multi_line.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_B.DATASET_B.TABLE_B",
-                        LineNumber=25,
-                        LineString="    PROJECT_B.DATASET_B.TABLE_B AS b",
+                        Line={
+                            MapKey.LINE_NUMBER: 25,
+                            MapKey.LINE_STRING: "    PROJECT_B.DATASET_B.TABLE_B AS b",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
-                        LineNumber=7,
-                        LineString="        PROJECT_C.DATASET_C.TABLE_C",
+                        Line={
+                            MapKey.LINE_NUMBER: 7,
+                            MapKey.LINE_STRING: "        PROJECT_C.DATASET_C.TABLE_C",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_d.DATASET_d.TABLE_d",
-                        LineNumber=17,
-                        LineString="        PROJECT_d.DATASET_d.TABLE_d",
+                        Line={
+                            MapKey.LINE_NUMBER: 17,
+                            MapKey.LINE_STRING: "        PROJECT_d.DATASET_d.TABLE_d",
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/nested_join.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_B.DATASET_B.TABLE_B",
-                        LineNumber=4,
-                        LineString="    PROJECT_B.DATASET_B.TABLE_B AS b",
+                        Line={
+                            MapKey.LINE_NUMBER: 4,
+                            MapKey.LINE_STRING: "    PROJECT_B.DATASET_B.TABLE_B AS b",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
-                        LineNumber=10,
-                        LineString="            PROJECT_C.DATASET_C.TABLE_C",
+                        Line={
+                            MapKey.LINE_NUMBER: 10,
+                            MapKey.LINE_STRING: "            PROJECT_C.DATASET_C.TABLE_C",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_d.DATASET_d.TABLE_d",
-                        LineNumber=20,
-                        LineString=("            PROJECT_d.DATASET_d.TABLE_d d"),
+                        Line={
+                            MapKey.LINE_NUMBER: 20,
+                            MapKey.LINE_STRING: (
+                                "            PROJECT_d.DATASET_d.TABLE_d d"
+                            ),
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_e.DATASET_e.TABLE_e",
-                        LineNumber=21,
-                        LineString=(
-                            "            LEFT OUTER JOIN PROJECT_e.DATASET_e.TABLE_e"
-                        ),
+                        Line={
+                            MapKey.LINE_NUMBER: 21,
+                            MapKey.LINE_STRING: (
+                                "            LEFT OUTER JOIN "
+                                "PROJECT_e.DATASET_e.TABLE_e"
+                            ),
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/union_same_table.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName=("test_project.beam_streaming.taxirides_realtime"),
-                        LineNumber=6,
-                        LineString=(
-                            "    test_project.beam_streaming.taxirides_realtime"
-                        ),
+                        Line={
+                            MapKey.LINE_NUMBER: 6,
+                            MapKey.LINE_STRING: (
+                                "    test_project.beam_streaming.taxirides_realtime"
+                            ),
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName=("test_project.beam_streaming.taxirides_realtime"),
-                        LineNumber=15,
-                        LineString=(
-                            "    test_project.beam_streaming.taxirides_realtime"
-                        ),
+                        Line={
+                            MapKey.LINE_NUMBER: 15,
+                            MapKey.LINE_STRING: (
+                                "    test_project.beam_streaming.taxirides_realtime"
+                            ),
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/cte_multi_tables_01.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_A",
-                        LineNumber=6,
-                        LineString="		project.dataset.table_test_A",
+                        Line={
+                            MapKey.LINE_NUMBER: 6,
+                            MapKey.LINE_STRING: "		project.dataset.table_test_A",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_B",
-                        LineNumber=13,
-                        LineString="		project.dataset.table_test_B AS test_B",
+                        Line={
+                            MapKey.LINE_NUMBER: 13,
+                            MapKey.LINE_STRING: "		project.dataset.table_test_B AS test_B",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_C",
-                        LineNumber=19,
-                        LineString=("FROM project.dataset.table_test_C AS test_C"),
+                        Line={
+                            MapKey.LINE_NUMBER: 19,
+                            MapKey.LINE_STRING: (
+                                "FROM project.dataset.table_test_C AS test_C"
+                            ),
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/cte_multi_tables_02.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_A",
-                        LineNumber=6,
-                        LineString=("		project.dataset.table_test_A -- table_test_B"),
+                        Line={
+                            MapKey.LINE_NUMBER: 6,
+                            MapKey.LINE_STRING: (
+                                "		project.dataset.table_test_A -- table_test_B"
+                            ),
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_B",
-                        LineNumber=12,
-                        LineString="		project.dataset.table_test_B AS test_B",
+                        Line={
+                            MapKey.LINE_NUMBER: 12,
+                            MapKey.LINE_STRING: "		project.dataset.table_test_B AS test_B",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_C",
-                        LineNumber=19,
-                        LineString="		project.dataset.table_test_C AS test_C",
+                        Line={
+                            MapKey.LINE_NUMBER: 19,
+                            MapKey.LINE_STRING: "		project.dataset.table_test_C AS test_C",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="project.dataset.table_test_D",
-                        LineNumber=26,
-                        LineString=("FROM project.dataset.table_test_D AS test_D"),
+                        Line={
+                            MapKey.LINE_NUMBER: 26,
+                            MapKey.LINE_STRING: (
+                                "FROM project.dataset.table_test_D AS test_D"
+                            ),
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/backtick_each_elements.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="dummy.dummy.my_first_dbt_model",
-                        LineNumber=4,
-                        LineString=("from `dummy`.`dummy`.`my_first_dbt_model`"),
+                        Line={
+                            MapKey.LINE_NUMBER: 4,
+                            MapKey.LINE_STRING: (
+                                "from `dummy`.`dummy`.`my_first_dbt_model`"
+                            ),
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/backtick_whole_element.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="dummy.dummy.my_first_dbt_model",
-                        LineNumber=4,
-                        LineString="from `dummy.dummy.my_first_dbt_model`",
+                        Line={
+                            MapKey.LINE_NUMBER: 4,
+                            MapKey.LINE_STRING: "from `dummy.dummy.my_first_dbt_model`",
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/google_bigquery_unnest_in_exists.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="PROJECT_d.DATASET_e.TABLE_f",
-                        LineNumber=5,
-                        LineString="    PROJECT_d.DATASET_e.TABLE_f",
+                        Line={
+                            MapKey.LINE_NUMBER: 5,
+                            MapKey.LINE_STRING: "    PROJECT_d.DATASET_e.TABLE_f",
+                        },
                     ),
                 ],
             ),
             (
                 "tests/sql/query/contains_str_from.sql",
                 [
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="test.cte",
-                        LineNumber=5,
-                        LineString="        test.cte",
+                        Line={
+                            MapKey.LINE_NUMBER: 5,
+                            MapKey.LINE_STRING: "        test.cte",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="test.main",
-                        LineNumber=11,
-                        LineString="    test.main",
+                        Line={
+                            MapKey.LINE_NUMBER: 11,
+                            MapKey.LINE_STRING: "    test.main",
+                        },
                     ),
-                    UpstairsReference(
+                    UpstairsTableReference(
                         TableName="test.sub",
-                        LineNumber=13,
-                        LineString="    test.sub ON",
+                        Line={
+                            MapKey.LINE_NUMBER: 13,
+                            MapKey.LINE_STRING: "    test.sub ON",
+                        },
                     ),
                 ],
             ),
@@ -264,7 +332,7 @@ class TestSuccess:
             query_str = f.read()
         query = Query(query_str=query_str)
         actual = []
-        for result in query.detect_upstairs_reference():
+        for result in query.detect_upstairs_table_reference():
             actual.append(result)
         assert actual == expected
 

--- a/tests/stairlight/test_query.py
+++ b/tests/stairlight/test_query.py
@@ -132,7 +132,9 @@ class TestSuccess:
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
                         Line={
                             MapKey.LINE_NUMBER: 10,
-                            MapKey.LINE_STRING: "            PROJECT_C.DATASET_C.TABLE_C",
+                            MapKey.LINE_STRING: (
+                                "            PROJECT_C.DATASET_C.TABLE_C"
+                            ),
                         },
                     ),
                     UpstairTableReference(
@@ -193,7 +195,9 @@ class TestSuccess:
                         TableName="project.dataset.table_test_B",
                         Line={
                             MapKey.LINE_NUMBER: 13,
-                            MapKey.LINE_STRING: "		project.dataset.table_test_B AS test_B",
+                            MapKey.LINE_STRING: (
+                                "		project.dataset.table_test_B AS test_B"
+                            ),
                         },
                     ),
                     UpstairTableReference(
@@ -223,14 +227,18 @@ class TestSuccess:
                         TableName="project.dataset.table_test_B",
                         Line={
                             MapKey.LINE_NUMBER: 12,
-                            MapKey.LINE_STRING: "		project.dataset.table_test_B AS test_B",
+                            MapKey.LINE_STRING: (
+                                "		project.dataset.table_test_B AS test_B"
+                            ),
                         },
                     ),
                     UpstairTableReference(
                         TableName="project.dataset.table_test_C",
                         Line={
                             MapKey.LINE_NUMBER: 19,
-                            MapKey.LINE_STRING: "		project.dataset.table_test_C AS test_C",
+                            MapKey.LINE_STRING: (
+                                "		project.dataset.table_test_C AS test_C"
+                            ),
                         },
                     ),
                     UpstairTableReference(

--- a/tests/stairlight/test_query.py
+++ b/tests/stairlight/test_query.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.stairlight.query import Query, UpstairsTableReference, solve_table_prefix
+from src.stairlight.query import Query, UpstairTableReference, solve_table_prefix
 from src.stairlight.source.config import MapKey
 
 
@@ -11,18 +11,18 @@ class TestSuccess:
             "INNER JOIN PROJECT_X.DATASET_X.TABLE_Y USING(ID)"
         )
         query = Query(query_str=query_str)
-        results: list[UpstairsTableReference] = []
-        for result in query.detect_upstairs_table_reference():
+        results: list[UpstairTableReference] = []
+        for result in query.detect_upstair_table_reference():
             results.append(result)
         assert results == [
-            UpstairsTableReference(
+            UpstairTableReference(
                 TableName="PROJECT_X.DATASET_X.TABLE_X",
                 Line={
                     MapKey.LINE_NUMBER: 1,
                     MapKey.LINE_STRING: "SELECT * FROM PROJECT_X.DATASET_X.TABLE_X ",
                 },
             ),
-            UpstairsTableReference(
+            UpstairTableReference(
                 TableName="PROJECT_X.DATASET_X.TABLE_Y",
                 Line={
                     MapKey.LINE_NUMBER: 2,
@@ -39,7 +39,7 @@ class TestSuccess:
             (
                 "tests/sql/query/cte_one_line.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_B.DATASET_B.TABLE_B",
                         Line={
                             MapKey.LINE_NUMBER: 1,
@@ -56,7 +56,7 @@ class TestSuccess:
                             ),
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
                         Line={
                             MapKey.LINE_NUMBER: 1,
@@ -73,7 +73,7 @@ class TestSuccess:
                             ),
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_d.DATASET_d.TABLE_d",
                         Line={
                             MapKey.LINE_NUMBER: 1,
@@ -95,21 +95,21 @@ class TestSuccess:
             (
                 "tests/sql/query/cte_multi_line.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_B.DATASET_B.TABLE_B",
                         Line={
                             MapKey.LINE_NUMBER: 25,
                             MapKey.LINE_STRING: "    PROJECT_B.DATASET_B.TABLE_B AS b",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
                         Line={
                             MapKey.LINE_NUMBER: 7,
                             MapKey.LINE_STRING: "        PROJECT_C.DATASET_C.TABLE_C",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_d.DATASET_d.TABLE_d",
                         Line={
                             MapKey.LINE_NUMBER: 17,
@@ -121,21 +121,21 @@ class TestSuccess:
             (
                 "tests/sql/query/nested_join.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_B.DATASET_B.TABLE_B",
                         Line={
                             MapKey.LINE_NUMBER: 4,
                             MapKey.LINE_STRING: "    PROJECT_B.DATASET_B.TABLE_B AS b",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_C.DATASET_C.TABLE_C",
                         Line={
                             MapKey.LINE_NUMBER: 10,
                             MapKey.LINE_STRING: "            PROJECT_C.DATASET_C.TABLE_C",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_d.DATASET_d.TABLE_d",
                         Line={
                             MapKey.LINE_NUMBER: 20,
@@ -144,7 +144,7 @@ class TestSuccess:
                             ),
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_e.DATASET_e.TABLE_e",
                         Line={
                             MapKey.LINE_NUMBER: 21,
@@ -159,7 +159,7 @@ class TestSuccess:
             (
                 "tests/sql/query/union_same_table.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName=("test_project.beam_streaming.taxirides_realtime"),
                         Line={
                             MapKey.LINE_NUMBER: 6,
@@ -168,7 +168,7 @@ class TestSuccess:
                             ),
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName=("test_project.beam_streaming.taxirides_realtime"),
                         Line={
                             MapKey.LINE_NUMBER: 15,
@@ -182,21 +182,21 @@ class TestSuccess:
             (
                 "tests/sql/query/cte_multi_tables_01.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_A",
                         Line={
                             MapKey.LINE_NUMBER: 6,
                             MapKey.LINE_STRING: "		project.dataset.table_test_A",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_B",
                         Line={
                             MapKey.LINE_NUMBER: 13,
                             MapKey.LINE_STRING: "		project.dataset.table_test_B AS test_B",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_C",
                         Line={
                             MapKey.LINE_NUMBER: 19,
@@ -210,7 +210,7 @@ class TestSuccess:
             (
                 "tests/sql/query/cte_multi_tables_02.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_A",
                         Line={
                             MapKey.LINE_NUMBER: 6,
@@ -219,21 +219,21 @@ class TestSuccess:
                             ),
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_B",
                         Line={
                             MapKey.LINE_NUMBER: 12,
                             MapKey.LINE_STRING: "		project.dataset.table_test_B AS test_B",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_C",
                         Line={
                             MapKey.LINE_NUMBER: 19,
                             MapKey.LINE_STRING: "		project.dataset.table_test_C AS test_C",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="project.dataset.table_test_D",
                         Line={
                             MapKey.LINE_NUMBER: 26,
@@ -247,7 +247,7 @@ class TestSuccess:
             (
                 "tests/sql/query/backtick_each_elements.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="dummy.dummy.my_first_dbt_model",
                         Line={
                             MapKey.LINE_NUMBER: 4,
@@ -261,7 +261,7 @@ class TestSuccess:
             (
                 "tests/sql/query/backtick_whole_element.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="dummy.dummy.my_first_dbt_model",
                         Line={
                             MapKey.LINE_NUMBER: 4,
@@ -273,7 +273,7 @@ class TestSuccess:
             (
                 "tests/sql/query/google_bigquery_unnest_in_exists.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="PROJECT_d.DATASET_e.TABLE_f",
                         Line={
                             MapKey.LINE_NUMBER: 5,
@@ -285,21 +285,21 @@ class TestSuccess:
             (
                 "tests/sql/query/contains_str_from.sql",
                 [
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="test.cte",
                         Line={
                             MapKey.LINE_NUMBER: 5,
                             MapKey.LINE_STRING: "        test.cte",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="test.main",
                         Line={
                             MapKey.LINE_NUMBER: 11,
                             MapKey.LINE_STRING: "    test.main",
                         },
                     ),
-                    UpstairsTableReference(
+                    UpstairTableReference(
                         TableName="test.sub",
                         Line={
                             MapKey.LINE_NUMBER: 13,
@@ -332,7 +332,7 @@ class TestSuccess:
             query_str = f.read()
         query = Query(query_str=query_str)
         actual = []
-        for result in query.detect_upstairs_table_reference():
+        for result in query.detect_upstair_table_reference():
             actual.append(result)
         assert actual == expected
 

--- a/tests/stairlight/test_query.py
+++ b/tests/stairlight/test_query.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from src.stairlight.query import Query, UpstairTableReference, solve_table_prefix

--- a/tests/stairlight/test_stairlight.py
+++ b/tests/stairlight/test_stairlight.py
@@ -51,7 +51,21 @@ class TestStairLight:
         assert self.stairlight.has_stairlight_config()
 
     def test_mapped(self):
-        assert self.stairlight.mapped
+        actual = set()
+        upstairs = self.stairlight.mapped["PROJECT_J.DATASET_K.TABLE_L"]
+        for mapped_templates in upstairs.values():
+            actual.update(
+                set([mapped_template.Key for mapped_template in mapped_templates])
+            )
+        assert (
+            set(
+                [
+                    "tests/sql/main/cte_multi_line_params.sql",
+                    "tests/sql/main/cte_multi_line_params_copy.sql",
+                ]
+            )
+            == actual
+        )
 
     def test_mapped_exclude_empty_value(self):
         assert "dummy.dummy.my_first_dbt_model" not in self.stairlight.mapped.keys()
@@ -156,6 +170,7 @@ class TestStairLight:
         assert sorted(result) == [
             f"{tests_abspath}/sql/main/cte_multi_line.sql",
             f"{tests_abspath}/sql/main/cte_multi_line_params.sql",
+            f"{tests_abspath}/sql/main/cte_multi_line_params_copy.sql",
             f"{tests_abspath}/sql/main/one_line_3.sql",
         ]
 

--- a/tests/stairlight/test_stairlight.py
+++ b/tests/stairlight/test_stairlight.py
@@ -219,16 +219,16 @@ class TestStairLight:
         ]
 
     def test_create_relative_map_up(self):
-        table_name = "PROJECT_d.DATASET_d.TABLE_d"
+        target_table_name = "PROJECT_d.DATASET_d.TABLE_d"
         result = self.stairlight.create_relative_map(
-            table_name=table_name, direction=SearchDirection.UP
+            target_table_name=target_table_name, direction=SearchDirection.UP
         )
         assert "PROJECT_e.DATASET_e.TABLE_e" in result
 
     def test_create_relative_map_down(self):
-        table_name = "PROJECT_A.DATASET_A.TABLE_A"
+        target_table_name = "PROJECT_A.DATASET_A.TABLE_A"
         result = self.stairlight.create_relative_map(
-            table_name=table_name, direction=SearchDirection.DOWN
+            target_table_name=target_table_name, direction=SearchDirection.DOWN
         )
         assert "PROJECT_A.DATASET_B.TABLE_C" in result
 

--- a/tests/stairlight/test_stairlight.py
+++ b/tests/stairlight/test_stairlight.py
@@ -292,6 +292,15 @@ class TestStairLight:
             expected: dict[str, Any] = json.load(f)
         assert actual == expected
 
+    def test_cast_mapped_dict_all(self):
+        casted = self.stairlight.cast_mapped_dict_all(mapped=self.stairlight.mapped)
+        all_mapped_templates: list = []
+        for upstairs in casted.values():
+            for mapped_templates in upstairs.values():
+                all_mapped_templates = all_mapped_templates + mapped_templates
+
+        assert all([isinstance(actual, dict) for actual in all_mapped_templates])
+
 
 @pytest.mark.integration
 class TestStairLightNoConfig:


### PR DESCRIPTION
At https://github.com/tosh2230/stairlight/commit/d4988f2467b13edfe14d11cfb19543b54380d46f, stairlight outputs one dict per upstream table.

```json
$ stairlight -c tests/config | jq '."PROJECT_J.DATASET_K.TABLE_L"."PROJECT_P.DATASET_Q.TABLE_R"'
{
  "TemplateSourceType": "File",
  "Key": "tests/sql/main/cte_multi_line_params_copy.sql",
  "Uri": "/project/stairlight/tests/sql/main/cte_multi_line_params_copy.sql",
  "Lines": [
    {
      "LineNumber": 32,
      "LineString": "    PROJECT_P.DATASET_Q.TABLE_R AS b"
    },
    {
      "LineNumber": 23,
      "LineString": "    PROJECT_P.DATASET_Q.TABLE_R AS b"
    }
  ],
  "Labels": {
    "Source": "file",
    "Test": "c"
  }
}
```

This PR changes it to a list of dicts.

```json
$ stairlight -c tests/config | jq '."PROJECT_J.DATASET_K.TABLE_L"."PROJECT_P.DATASET_Q.TABLE_R"'
[
  {
    "TemplateSourceType": "File",
    "Key": "tests/sql/main/cte_multi_line_params_copy.sql",
    "Uri": "/project/stairlight/tests/sql/main/cte_multi_line_params_copy.sql",
    "Lines": [
      {
        "LineNumber": 32,
        "LineString": "    PROJECT_P.DATASET_Q.TABLE_R AS b"
      },
      {
        "LineNumber": 23,
        "LineString": "    PROJECT_P.DATASET_Q.TABLE_R AS b"
      }
    ],
    "Labels": {
      "Source": "file",
      "Test": "c"
    }
  },
  {
    "TemplateSourceType": "File",
    "Key": "tests/sql/main/cte_multi_line_params.sql",
    "Uri": "/project/stairlight/tests/sql/main/cte_multi_line_params.sql",
    "Lines": [
      {
        "LineNumber": 23,
        "LineString": "    PROJECT_P.DATASET_Q.TABLE_R AS b"
      }
    ],
    "Labels": {
      "Source": "file",
      "Test": "c"
    }
  }
]
```

In the process, I've refactored data structures about "map".